### PR TITLE
Change artifact names

### DIFF
--- a/.github/ci.sh
+++ b/.github/ci.sh
@@ -44,6 +44,9 @@ build_yices() {
     curl -o yices.zip -sL "https://yices.csl.sri.com/releases/2.6.2/yices-2.6.2-x86_64-pc-mingw32-static-gmp.zip"
     unzip yices.zip
     cp yices-*/bin/* $BIN
+    mv $BIN/yices-sat.exe $BIN/yices_sat.exe
+    mv $BIN/yices-smt.exe $BIN/yices_smt.exe
+    mv $BIN/yices-smt2.exe $BIN/yices_smt2.exe
   else
     export CPPFLAGS="-I$TOP/install-root/include"
     export LDFLAGS="-L$TOP/install-root/lib"

--- a/.github/ci.sh
+++ b/.github/ci.sh
@@ -100,6 +100,7 @@ build_solvers() {
   build_cvc4
   build_z3
   $IS_WIN || chmod +x $BIN/*
+  strip $BIN/*
 }
 
 COMMAND="$1"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install dependencies (macOS)
         run: |
           brew update
-          brew install gperf
+          brew install gperf automake autoconf
         if: runner.os == 'macOS'
 
       - name: Install dependencies (Windows)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, macos-latest, windows-latest]
+        os: [ubuntu-20.04, ubuntu-18.04, macos-10.15, windows-2019]
     steps:
       - uses: actions/checkout@v2
         with:
@@ -75,7 +75,7 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           path: bin
-          name: ${{ runner.os }}-bin
+          name: ${{ matrix.os }}-bin
 
   # Indicates sufficient CI success for the purposes of mergify merging the pull
   # request, see .github/mergify.yml. This is done instead of enumerating each
@@ -84,7 +84,7 @@ jobs:
   # - changes to jobs or job instances don't require a mergify config update
   # - dependencies through `needs:` are validated, CI will fail if it's invalid
   mergify:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs:
       - build
     steps:


### PR DESCRIPTION
* Make the artifact ZIP files contain the name of the full runner tag, not just the OS name.
* Ensure that the executable names on Windows are the same as on Linux and macOS.
* Ensure that binaries are stripped on all platforms.