### PR TITLE
Added -O2 flag to windows and linux builds of ABC

### DIFF
--- a/.github/ci.sh
+++ b/.github/ci.sh
@@ -32,9 +32,9 @@ build_abc() {
     echo "double Cudd_CountMinterm( DdManager * manager, DdNode * node, int nvars ) { return 0.0; }" >> src/base/abci/abc.c
     # Work around https://github.com/berkeley-abc/abc/issues/154
     patch -p1 -i $PATCHES/abc-intptr_t.patch
-    make ABC_USE_NO_READLINE=1 ABC_USE_NO_PTHREADS=1 ABC_USE_NO_CUDD=1 CXXFLAGS="-fpermissive -DNT64 -DWIN32_NO_DLL" CFLAGS="-DNT64 -DWIN32_NO_DLL" LDFLAGS="-static" -j4 abc
+    make OPTFLAGS="-O2" ABC_USE_NO_READLINE=1 ABC_USE_NO_PTHREADS=1 ABC_USE_NO_CUDD=1 CXXFLAGS="-fpermissive -DNT64 -DWIN32_NO_DLL" CFLAGS="-DNT64 -DWIN32_NO_DLL" LDFLAGS="-static" -j4 abc
   else
-    make -j4 abc
+    make OPTFLAGS="-O2" -j4 abc
   fi
   cp abc$EXT $BIN
   (cd $BIN && deps abc$EXT && ./abc$EXT -S "%blast; &sweep -C 5000; &syn4; &cec -m -s" < $PROBLEM)


### PR DESCRIPTION
In my experiments on macos, this compiler flag speeds up abc by about a factor of 10. I have not tested the Linux or Windows build, but thought to add the flag assuming that other OSs will also benefit.