### PR TITLE
Add Ubuntu 22.04 binaries, drop Ubuntu 18.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, ubuntu-18.04, macos-12, windows-2019]
+        os: [ubuntu-22.04, ubuntu-20.04, macos-12, windows-2019]
         solver: [abc, boolector, cvc4, cvc5, yices, z3]
     steps:
       - uses: actions/checkout@v2
@@ -93,7 +93,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, ubuntu-18.04, macos-12, windows-2019]
+        os: [ubuntu-22.04, ubuntu-20.04, macos-12, windows-2019]
     steps:
 
       - uses: actions/download-artifact@v2


### PR DESCRIPTION
Marking as a draft until GitHub Actions' Ubuntu 22.04 runners have left public beta.

Fixes #21.