### PR TITLE
Use macOS 12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, ubuntu-18.04, macos-10.15, windows-2019]
+        os: [ubuntu-20.04, ubuntu-18.04, macos-12, windows-2019]
         solver: [abc, boolector, cvc4, cvc5, yices, z3]
     steps:
       - uses: actions/checkout@v2
@@ -93,7 +93,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, ubuntu-18.04, macos-10.15, windows-2019]
+        os: [ubuntu-20.04, ubuntu-18.04, macos-12, windows-2019]
     steps:
 
       - uses: actions/download-artifact@v2


### PR DESCRIPTION
GitHub is deprecating (and eventually removing) its macOS 10.15 runners. See https://github.com/actions/virtual-environments/issues/5583. We might as well take the opportunity to upgrade the macOS version we are building for.