### PR TITLE
Backport fix for cvc5/cvc5#9567

### DIFF
--- a/.github/ci.sh
+++ b/.github/ci.sh
@@ -97,6 +97,10 @@ build_cvc5() {
     # (Ideally, there would be a CMake configuration option to accomplish this,
     # but I have not found one.)
     patch -p1 -i $PATCHES/cvc5-no-ld-gold.patch
+    # Fix a Windows-only segfault reported in
+    # https://github.com/cvc5/cvc5/issues/9567. This backports the fix from
+    # https://github.com/cvc5/cvc5/pull/9580.
+    patch -p1 -i $PATCHES/cvc5-upgrade-libpoly.patch
     # Why do we manually override Python_EXECUTABLE below? GitHub Actions comes
     # with multiple versions of Python pre-installed, and for some bizarre
     # reason, CMake always tries to pick the latest version, even if it is not

--- a/patches/cvc5-upgrade-libpoly.patch
+++ b/patches/cvc5-upgrade-libpoly.patch
@@ -1,0 +1,35 @@
+From cbecdbe5b14c08240aaf12cdb8cec010cab6ad09 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Vin=C3=ADcius=20Camillo?=
+ <98857171+vrcamillo@users.noreply.github.com>
+Date: Wed, 22 Mar 2023 12:19:50 -0300
+Subject: [PATCH] Upgrading LibPoly. (#9580)
+
+Upgrading LibPoly to fix a segmentation violation.
+
+Fixes #9567.
+---
+ cmake/FindPoly.cmake | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/cmake/FindPoly.cmake b/cmake/FindPoly.cmake
+index 9041890a203..f28b5a005e9 100644
+--- a/cmake/FindPoly.cmake
++++ b/cmake/FindPoly.cmake
+@@ -45,7 +45,7 @@ if(NOT Poly_FOUND_SYSTEM)
+
+   include(ExternalProject)
+
+-  set(Poly_VERSION "1383809f2aa5005ef20110fec84b66959518f697")
++  set(Poly_VERSION "126147f1ceae9f771a68bad9cbc199cf96daec46")
+
+   check_if_cross_compiling(CCWIN "Windows" "")
+   if(CCWIN)
+@@ -158,7 +158,7 @@ if(NOT Poly_FOUND_SYSTEM)
+     Poly-EP
+     ${COMMON_EP_CONFIG}
+     URL https://github.com/SRI-CSL/libpoly/archive/${Poly_VERSION}.tar.gz
+-    URL_HASH SHA1=e3da80491b378a4d874073d201406eb011f47c19
++    URL_HASH SHA1=5ebbd00c8dc8b731b5382701a23c60607bcb2804
+     PATCH_COMMAND
+       sed -i.orig
+       "s,add_subdirectory(test/polyxx),add_subdirectory(test/polyxx EXCLUDE_FROM_ALL),g"


### PR DESCRIPTION
This issue causes CVC5 to segfault on Windows when given certain queries involving algebraic reals. This backports the fix from cvc5/cvc5#9580.