### PR TITLE
Use `mkdir -p` instead of `mkdir` to ease rerunning `yices` installation

### DIFF
--- a/.github/ci.sh
+++ b/.github/ci.sh
@@ -131,6 +131,7 @@ build_yices() {
     export CONFIGURE_FLAGS="--prefix=$TOP/install-root"
   fi
 
+  mkdir -p install-root
   mkdir -p install-root/include
   mkdir -p install-root/lib
 

--- a/.github/ci.sh
+++ b/.github/ci.sh
@@ -133,7 +133,6 @@ build_yices() {
     export CONFIGURE_FLAGS="--prefix=$TOP/install-root"
   fi
 
-  mkdir -p install-root
   mkdir -p install-root/include
   mkdir -p install-root/lib
 

--- a/.github/ci.sh
+++ b/.github/ci.sh
@@ -131,9 +131,8 @@ build_yices() {
     export CONFIGURE_FLAGS="--prefix=$TOP/install-root"
   fi
 
-  mkdir install-root
-  mkdir install-root/include
-  mkdir install-root/lib
+  mkdir -p install-root/include
+  mkdir -p install-root/lib
 
   (cd repos && curl -o gmp.tar.lz -sL "https://gmplib.org/download/gmp/gmp-6.2.1.tar.lz" && tar xf gmp.tar.lz)
 


### PR DESCRIPTION
See above.