### PR TITLE
Patch ANTLR build process to check for `aarch64` architecture

### DIFF
--- a/.github/ci.sh
+++ b/.github/ci.sh
@@ -62,6 +62,7 @@ build_boolector() {
 
 build_cvc4() {
   pushd repos/CVC4-archived
+  patch -p1 -i $PATCHES/cvc4-antlr-check-aarch64.patch
   ./contrib/get-antlr-3.4
   ./contrib/get-symfpu
   if $IS_WIN ; then

--- a/patches/cvc4-antlr-check-aarch64.patch
+++ b/patches/cvc4-antlr-check-aarch64.patch
@@ -1,0 +1,31 @@
+diff --git a/contrib/get-antlr-3.4 b/contrib/get-antlr-3.4
+index 45dc86583..ea69b4b7f 100755
+--- a/contrib/get-antlr-3.4
++++ b/contrib/get-antlr-3.4
+@@ -47,7 +47,7 @@ cd "$ANTLR_HOME_DIR/libantlr3c-3.4"
+ 
+ # Make antlr3debughandlers.c empty to avoid unreferenced symbols
+ rm -rf src/antlr3debughandlers.c && touch src/antlr3debughandlers.c
+-if [ "${MACHINE_TYPE}" == 'x86_64' ]; then
++if [[ "${MACHINE_TYPE}" == 'x86_64' || "${MACHINE_TYPE}" == 'aarch64' ]]; then
+   # 64-bit stuff here
+   ./configure --enable-64bit --disable-antlrdebug --prefix="$INSTALL_DIR" $ANTLR_CONFIGURE_ARGS $BUILD_TYPE
+ else
+@@ -67,7 +67,7 @@ fi
+ mv "$INSTALL_LIB_DIR/libantlr3c.a" "$INSTALL_LIB_DIR/libantlr3c-static.a"
+ make clean
+ 
+-if [ "${MACHINE_TYPE}" == 'x86_64' ]; then
++if [[ "${MACHINE_TYPE}" == 'x86_64' || "${MACHINE_TYPE}" == 'aarch64' ]]; then
+   # 64-bit stuff here
+   ./configure --enable-64bit --with-pic --disable-antlrdebug --prefix="$INSTALL_DIR" $ANTLR_CONFIGURE_ARGS $BUILD_TYPE
+ else
+@@ -84,7 +84,7 @@ mv "$INSTALL_LIB_DIR/libantlr3c.la" "$INSTALL_LIB_DIR/libantlr3c.la.orig"
+ awk '/^old_library=/ {print "old_library='\''libantlr3c-static.a'\''"} /^library_names=/ {print "library_names='\''libantlr3c.a'\''"} !/^old_library=/ && !/^library_names=/ {print}' < "$INSTALL_LIB_DIR/libantlr3c.la.orig" > "$INSTALL_LIB_DIR/libantlr3c.la"
+ rm "$INSTALL_LIB_DIR/libantlr3c.la.orig"
+ 
+-if [ "${MACHINE_TYPE}" == 'x86_64' ]; then
++if [[ "${MACHINE_TYPE}" == 'x86_64' || "${MACHINE_TYPE}" == 'aarch64' ]]; then
+   # 64-bit stuff here
+   echo ============== WARNING ====================
+   echo The script guessed that this machine is 64 bit.


### PR DESCRIPTION
As it stands, building ANTLR (as part of building CVC4) checks whether a machine has a 64-bit architecture by checking solely whether it is `x86_64`. This check fails to recognize that Apple-silicon Macs are 64-bit (since they tag themselves as `aarch64`). See #34 for more detail. Since CVC4 is archived, we need to generate and apply this patch ourselves during the build process. This PR effects that.