### PR TITLE
CI: Include architecture in archive names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           path: bin
-          name: ${{ matrix.os }}-${{ matrix.solver }}-bin
+          name: ${{ matrix.os }}-${{ runner.arch }}-${{ matrix.solver }}-bin
 
   package_solvers:
     runs-on: ${{ matrix.os }}
@@ -106,37 +106,37 @@ jobs:
     steps:
       - uses: actions/download-artifact@v2
         with:
-          name: "${{ matrix.os }}-abc-bin"
+          name: "${{ matrix.os }}-${{ runner.arch }}-abc-bin"
           path: bin
 
       - uses: actions/download-artifact@v2
         with:
-          name: "${{ matrix.os }}-boolector-bin"
+          name: "${{ matrix.os }}-${{ runner.arch }}-boolector-bin"
           path: bin
 
       - uses: actions/download-artifact@v2
         with:
-          name: "${{ matrix.os }}-cvc4-bin"
+          name: "${{ matrix.os }}-${{ runner.arch }}-cvc4-bin"
           path: bin
 
       - uses: actions/download-artifact@v2
         with:
-          name: "${{ matrix.os }}-cvc5-bin"
+          name: "${{ matrix.os }}-${{ runner.arch }}-cvc5-bin"
           path: bin
 
       - uses: actions/download-artifact@v2
         with:
-          name: "${{ matrix.os }}-yices-bin"
+          name: "${{ matrix.os }}-${{ runner.arch }}-yices-bin"
           path: bin
 
       - uses: actions/download-artifact@v2
         with:
-          name: "${{ matrix.os }}-z3-4.8.8-bin"
+          name: "${{ matrix.os }}-${{ runner.arch }}-z3-4.8.8-bin"
           path: bin
 
       - uses: actions/download-artifact@v2
         with:
-          name: "${{ matrix.os }}-z3-4.8.14-bin"
+          name: "${{ matrix.os }}-${{ runner.arch }}-z3-4.8.14-bin"
           path: bin
 
         # Make a copy of z3-<LATEST_Z3_VERSION> named z3 for ease of use.
@@ -150,7 +150,7 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           path: bin
-          name: ${{ matrix.os }}-bin
+          name: ${{ matrix.os }}-${{ runner.arch }}-bin
 
   # Indicates sufficient CI success for the purposes of mergify merging the pull
   # request, see .github/mergify.yml. This is done instead of enumerating each


### PR DESCRIPTION
For now, each configuration will always be the `X64` architecture, but we will also support `ARM64` in the not-too-distant future. (See #34.)