### PR TITLE
Enable CaDiCaL support when building `boolector`

### DIFF
--- a/.github/ci.sh
+++ b/.github/ci.sh
@@ -50,6 +50,7 @@ build_boolector() {
     patch -p1 -i $PATCHES/boolector-mingw64.patch
   fi
   ./contrib/setup-lingeling.sh
+  ./contrib/setup-cadical.sh
   ./contrib/setup-btor2tools.sh
   ./configure.sh --ninja
   cd build


### PR DESCRIPTION
Fixes #46.