### PR TITLE
Build solvers on macos-14 (M1 macOS)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, ubuntu-20.04, macos-12, windows-2019]
+        os: [ubuntu-22.04, ubuntu-20.04, macos-12, macos-14, windows-2019]
         solver: [abc, bitwuzla, boolector, cvc4, cvc5, yices, z3-4.8.8, z3-4.8.14]
     steps:
       - uses: actions/checkout@v2
@@ -105,7 +105,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, ubuntu-20.04, macos-12, windows-2019]
+        os: [ubuntu-22.04, ubuntu-20.04, macos-12, macos-14, windows-2019]
     steps:
       - uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.9'
+          python-version: '3.10'
 
       - name: Install Python libraries
         run: |

--- a/README.md
+++ b/README.md
@@ -20,15 +20,13 @@ Currently, `what4-solvers` offers the following solver versions:
 
 Built for the following operating systems:
 
-* macOS Monterey 12 (x86-64 and arm64)
+* macOS Monterey 12 (x86-64)
+* macOS Sonoma 14 (arm64)
 * Ubuntu 20.04 (x86-64)
 * Ubuntu 22.04 (x86-64)
 * Windows Server 2019 (x86-64)
 
-All of the binary distributions are built from CI with the exception of the
-arm64 macOS binaries, which are currently built manually. Eventually, we will
-produce the arm64 macOS binaries in CI as well. (See [this
-issue](https://github.com/GaloisInc/what4-solvers/issues/34).)
+All of the binary distributions are built from CI.
 
 ## FAQ
 


### PR DESCRIPTION
Now that GitHub Actions offers a free tier of macOS M1 CI runners (see https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/), let's build the solvers on them.

Fixes https://github.com/GaloisInc/what4-solvers/issues/34.