### PR TITLE
Upgrade CVC5 to 1.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Currently, `what4-solvers` offers the following solver versions:
 * Bitwuzla - [0.3.0](https://github.com/bitwuzla/bitwuzla/tree/2b5a4a867f3717ba1adc325adf8e69577e3cee5c)
 * Boolector - [3.2.2](https://github.com/Boolector/boolector/tree/e7aba964f69cd52dbe509e46e818a4411b316cd3)
 * CVC4 - [1.8](https://github.com/CVC4/CVC4-archived/tree/5247901077efbc7b9016ba35fded7a6ab459a379)
-* CVC5 - [1.0.8](https://github.com/cvc5/cvc5/tree/c8e12cd12b4d1a2b78c29f97ca54b1188557fae0)
+* CVC5 - [1.1.1](https://github.com/cvc5/cvc5/tree/ebfdf84d5698eeb83e0fa4e45101fe4a8f4543eb)
 * Yices - [2.6.2](https://github.com/SRI-CSL/yices2/tree/8509cfb5c294df3c0ac3a4814483f39c58879606)
 * Z3 - [4.8.8](https://github.com/Z3Prover/z3/tree/ad55a1f1c617a7f0c3dd735c0780fc758424c7f1) and
        [4.8.14](https://github.com/Z3Prover/z3/tree/df8f9d7dcb8b9f9b3de1072017b7c2b7f63f0af8)


### PR DESCRIPTION
This fixes a regression observed when using CVC5 1.0.8 in the Cryptol test suite.