### PR TITLE
Yices: Upgrade from 2.6.2 to 2.6.5, upgrade `gmp` from 6.2.1 to 6.3.0

### DIFF
--- a/.github/ci.sh
+++ b/.github/ci.sh
@@ -155,9 +155,10 @@ build_yices() {
   mkdir -p install-root/include
   mkdir -p install-root/lib
 
-  (cd repos && curl -o gmp.tar.lz -sL "https://ftp.gnu.org/gnu/gmp/gmp-6.2.1.tar.lz" && tar xf gmp.tar.lz)
+  GMP_VERSION="6.3.0"
+  (cd repos && curl -o gmp.tar.lz -sL "https://ftp.gnu.org/gnu/gmp/gmp-$GMP_VERSION.tar.lz" && tar xf gmp.tar.lz)
 
-  pushd repos/gmp-6.2.1
+  pushd "repos/gmp-$GMP_VERSION"
   ./configure $CONFIGURE_FLAGS
   make -j4
   make install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,14 @@ jobs:
         os: [ubuntu-22.04, ubuntu-20.04, macos-13, macos-14, windows-2019]
         solver: [abc, bitwuzla, boolector, cvc4, cvc5, yices, z3-4.8.8, z3-4.8.14]
     steps:
+      # This is necessary to clone the yices2 repo on Windows, as some of the
+      # repo's test cases exceed the Windows API's default file path limit of
+      # 260 characters.
+      - name: Enable long file paths on Windows
+        shell: bash
+        run: git config --system core.longpaths true
+        if: runner.os == 'Windows'
+
       - uses: actions/checkout@v4
         with:
           submodules: true

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Currently, `what4-solvers` offers the following solver versions:
 * Boolector - [3.2.2](https://github.com/Boolector/boolector/tree/e7aba964f69cd52dbe509e46e818a4411b316cd3)
 * CVC4 - [1.8](https://github.com/CVC4/CVC4-archived/tree/5247901077efbc7b9016ba35fded7a6ab459a379)
 * CVC5 - [1.1.1](https://github.com/cvc5/cvc5/tree/ebfdf84d5698eeb83e0fa4e45101fe4a8f4543eb)
-* Yices - [2.6.2](https://github.com/SRI-CSL/yices2/tree/8509cfb5c294df3c0ac3a4814483f39c58879606)
+* Yices - [2.6.5](https://github.com/SRI-CSL/yices2/tree/8e6297e233299631147f98659224c3118fc6a215)
 * Z3 - [4.8.8](https://github.com/Z3Prover/z3/tree/ad55a1f1c617a7f0c3dd735c0780fc758424c7f1) and
        [4.8.14](https://github.com/Z3Prover/z3/tree/df8f9d7dcb8b9f9b3de1072017b7c2b7f63f0af8)
 


### PR DESCRIPTION
This PR:

* Upgrades Yices from version 2.6.2 to 2.6.5 (the latest as of the time of writing)
* Upgrades `gmp` (a dependency that Yices statically links against) from 6.2.1 to 6.3.0. `gmp-6.2.1` was susceptible to a serious bug on ARM64 that manifested as Yices segfaulting on ARM64. `gmp-6.3.0` fixes this bug, and as a result, this PR fixes #58.