### PR TITLE
CI: Normalize Ubuntu runner names in bindists

### DIFF
--- a/.github/ci.sh
+++ b/.github/ci.sh
@@ -238,6 +238,21 @@ cleanup_bins() {
   strip $BIN/*
 }
 
+# GitHub Actions' Ubuntu runners have somewhat unusual naming conventions. For
+# instance, there are both ubuntu-24.04 and ubuntu-24.04-arm runners. Each of
+# them has a distinct architecture (the former is x86-64, and the latter is
+# ARM64), but only ubuntu-24.04-arm explicitly encodes its architecture in the
+# runner name.
+#
+# For the sake of producing what4-solvers binary distributions, we would like to
+# normalize all Ubuntu 24.04 runner names to just "ubuntu-24.04". (We attach the
+# architecture to the bindist name separately.)
+normalize_runner_name() {
+  ORIG_NAME="$1"
+  NORMALIZED_NAME=${ORIG_NAME%"-arm"}
+  echo "$NORMALIZED_NAME"
+}
+
 COMMAND="$1"
 shift
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,10 @@ on:
 env:
   CACHE_VERSION: 1
   LATEST_Z3_VERSION: "4.8.14"
+  # Some of the runners (e.g., Windows) use very recent versions of CMake that
+  # are no longer compatible with CMake < 3.5, which is required by various
+  # solvers' builds. For now, we try using the recent CMake versions anyway.
+  CMAKE_POLICY_VERSION_MINIMUM: "3.5"
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,15 +95,11 @@ jobs:
       - name: build_solver (non-Windows)
         shell: bash
         run: .github/ci.sh build_${{ matrix.solver }}
-        env:
-          GITHUB_MATRIX_OS: ${{ matrix.os }}
         if: runner.os != 'Windows'
 
       - name: build_solver (Windows)
         shell: msys2 {0}
         run: .github/ci.sh build_${{ matrix.solver }}
-        env:
-          GITHUB_MATRIX_OS: ${{ matrix.os }}
         if: runner.os == 'Windows'
 
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,10 +102,16 @@ jobs:
         run: .github/ci.sh build_${{ matrix.solver }}
         if: runner.os == 'Windows'
 
+      # Needed to normalize both "ubuntu-24.04" and "ubuntu-24.04-arm" to
+      # "ubuntu-24.04" so that the Ubuntu ARM64 binaries don't accidentally
+      # mention ARM twice (#63).
+      - name: Normalize runner name
+        run: echo "OS_NAME=$(.github/ci.sh normalize_runner_name ${{ matrix.os }})" >> $GITHUB_ENV
+
       - uses: actions/upload-artifact@v4
         with:
           path: bin
-          name: ${{ matrix.os }}-${{ runner.arch }}-${{ matrix.solver }}-bin
+          name: ${{ env.OS_NAME }}-${{ runner.arch }}-${{ matrix.solver }}-bin
 
   package_solvers:
     runs-on: ${{ matrix.os }}
@@ -115,44 +121,55 @@ jobs:
       matrix:
         os: [ubuntu-24.04, ubuntu-24.04-arm, ubuntu-22.04, macos-13, macos-14, windows-2019]
     steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: false
+          fetch-depth: 1
+
+      # Needed to normalize both "ubuntu-24.04" and "ubuntu-24.04-arm" to
+      # "ubuntu-24.04" so that the Ubuntu ARM64 binaries don't accidentally
+      # mention ARM twice (#63).
+      - name: Normalize runner name
+        run: echo "OS_NAME=$(.github/ci.sh normalize_runner_name ${{ matrix.os }})" >> $GITHUB_ENV
+
       - uses: actions/download-artifact@v4
         with:
-          name: "${{ matrix.os }}-${{ runner.arch }}-abc-bin"
+          name: "${{ env.OS_NAME }}-${{ runner.arch }}-abc-bin"
           path: bin
 
       - uses: actions/download-artifact@v4
         with:
-          name: "${{ matrix.os }}-${{ runner.arch }}-bitwuzla-bin"
+          name: "${{ env.OS_NAME }}-${{ runner.arch }}-bitwuzla-bin"
           path: bin
 
       - uses: actions/download-artifact@v4
         with:
-          name: "${{ matrix.os }}-${{ runner.arch }}-boolector-bin"
+          name: "${{ env.OS_NAME }}-${{ runner.arch }}-boolector-bin"
           path: bin
 
       - uses: actions/download-artifact@v4
         with:
-          name: "${{ matrix.os }}-${{ runner.arch }}-cvc4-bin"
+          name: "${{ env.OS_NAME }}-${{ runner.arch }}-cvc4-bin"
           path: bin
 
       - uses: actions/download-artifact@v4
         with:
-          name: "${{ matrix.os }}-${{ runner.arch }}-cvc5-bin"
+          name: "${{ env.OS_NAME }}-${{ runner.arch }}-cvc5-bin"
           path: bin
 
       - uses: actions/download-artifact@v4
         with:
-          name: "${{ matrix.os }}-${{ runner.arch }}-yices-bin"
+          name: "${{ env.OS_NAME }}-${{ runner.arch }}-yices-bin"
           path: bin
 
       - uses: actions/download-artifact@v4
         with:
-          name: "${{ matrix.os }}-${{ runner.arch }}-z3-4.8.8-bin"
+          name: "${{ env.OS_NAME }}-${{ runner.arch }}-z3-4.8.8-bin"
           path: bin
 
       - uses: actions/download-artifact@v4
         with:
-          name: "${{ matrix.os }}-${{ runner.arch }}-z3-4.8.14-bin"
+          name: "${{ env.OS_NAME }}-${{ runner.arch }}-z3-4.8.14-bin"
           path: bin
 
         # Make a copy of z3-<LATEST_Z3_VERSION> named z3 for ease of use.
@@ -166,7 +183,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           path: bin
-          name: ${{ matrix.os }}-${{ runner.arch }}-bin
+          name: ${{ env.OS_NAME }}-${{ runner.arch }}-bin
 
   # Indicates sufficient CI success for the purposes of mergify merging the pull
   # request, see .github/mergify.yml. This is done instead of enumerating each


### PR DESCRIPTION
This ensures that we produce a bindist named `ubuntu-24.04-ARM64-bin.zip` instead of `ubuntu-24.04-arm-ARM64-bin.zip`.

Fixes https://github.com/GaloisInc/what4-solvers/issues/63.