### PR TITLE
Switch to a containerized build

### DIFF
--- a/.github/ci.sh
+++ b/.github/ci.sh
@@ -303,17 +303,9 @@ cleanup_bins() {
   strip "$BIN"/*
 }
 
-# GitHub Actions' runners have somewhat unusual naming conventions. For
-# instance, there are both ubuntu-24.04 and ubuntu-24.04-arm runners. Each of
-# them has a distinct architecture (the former is x86-64, and the latter is
-# ARM64), but only ubuntu-24.04-arm explicitly encodes its architecture in the
-# runner name. Similarly, there is a macos-15-intel runner that encodes the
-# architecture (Intel x86-64) in the runner name.
-#
-# For the sake of producing what4-solvers binary distributions, we would like to
-# normalize runner and container names. (We attach the architecture to the
-# bindist name separately.)
-normalize_runner_name() {
+# Covert the container name into a standard OS-ARCH string
+# Add a new case when a new container is added.
+normalize_container_name() {
   ORIG_NAME="$1"
   case "$ORIG_NAME" in
     "ubuntu:24.04")
@@ -325,14 +317,16 @@ normalize_runner_name() {
     "redhat/ubi9:latest")
       echo "redhat-ubi9"
       ;;
-    *)
-      # Default: strip "-arm" suffix from runner names
-      NORMALIZED_NAME=${ORIG_NAME%"-arm"}
-      # Strip -intel suffix (for macOS Intel runners)
-      NORMALIZED_NAME=${NORMALIZED_NAME%"-intel"}
-      echo "$NORMALIZED_NAME"
-      ;;
   esac
+}
+
+# The only runner that needs to be normalized is macos-15-intel
+# We strip the `-intel` suffix
+normalize_runner_name() {
+  ORIG_NAME="$1"
+  # Strip -intel suffix (for macOS Intel runners)
+  NORMALIZED_NAME=${ORIG_NAME%"-intel"}
+  echo "$NORMALIZED_NAME"
 }
 
 COMMAND="$1"

--- a/.github/ci.sh
+++ b/.github/ci.sh
@@ -303,7 +303,7 @@ cleanup_bins() {
   strip "$BIN"/*
 }
 
-# Covert the container name into a standard OS-ARCH string
+# Convert the container name into a standard OS-ARCH string
 # Add a new case when a new container is added.
 normalize_container_name() {
   ORIG_NAME="$1"

--- a/.github/ci.sh
+++ b/.github/ci.sh
@@ -317,6 +317,10 @@ normalize_container_name() {
     "redhat/ubi9:latest")
       echo "redhat-ubi9"
       ;;
+    *)
+      echo "Error: Unknown container name '$ORIG_NAME'" >&2
+      exit 1
+      ;;
   esac
 }
 

--- a/.github/ci.sh
+++ b/.github/ci.sh
@@ -356,12 +356,28 @@ test_solver() {
 # runner name.
 #
 # For the sake of producing what4-solvers binary distributions, we would like to
-# normalize all Ubuntu 24.04 runner names to just "ubuntu-24.04". (We attach the
-# architecture to the bindist name separately.)
+# normalize runner and container names. (We attach the architecture to the
+# bindist name separately.)
 normalize_runner_name() {
   ORIG_NAME="$1"
-  NORMALIZED_NAME=${ORIG_NAME%"-arm"}
-  echo "$NORMALIZED_NAME"
+  case "$ORIG_NAME" in
+    "ubuntu:24.04")
+      echo "ubuntu-24.04"
+      ;;
+    "ubuntu:22.04")
+      echo "ubuntu-22.04"
+      ;;
+    "redhat/ubi9:latest")
+      echo "redhat-ubi9"
+      ;;
+    *)
+      # Default: strip "-arm" suffix from runner names
+      NORMALIZED_NAME=${ORIG_NAME%"-arm"}
+      # Strip -intel suffix (for macOS Intel runners)
+      NORMALIZED_NAME=${NORMALIZED_NAME%"-intel"}
+      echo "$NORMALIZED_NAME"
+      ;;
+  esac
 }
 
 COMMAND="$1"

--- a/.github/ci.sh
+++ b/.github/ci.sh
@@ -50,12 +50,10 @@ ensure_static_gmp() {
     # On intel MacOS 15.x, gmp-6.3.0 started building broken libs full
     # of text relocations. Force --with-pic to stop this. Otherwise, gmp
     # succeeds, but the resulting library doesn't work.
-    # To make the set of configure flags slightly more consistent, we always use
-    # --with-pic on macOS, both on x86-64 and AArch64.
-    case "$RUNNER_OS" in
-      macOS) GMP_CONFIGURE_FLAGS=--with-pic;;
-      *) GMP_CONFIGURE_FLAGS=;;
-    esac
+    # On Linux, -fPIC is also required when building shared objects that link
+    # against this static library (e.g., bitwuzla's GMP C++ bindings).
+    # For consistency and to avoid relocation errors, always use --with-pic.
+    GMP_CONFIGURE_FLAGS=--with-pic
 
     ./configure --prefix="$TOP/install-root" --enable-static --disable-shared --enable-cxx $GMP_CONFIGURE_FLAGS
     make -j4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,8 +189,8 @@ jobs:
 
       - name: Install Python libraries
         run: |
-          python3 -m pip install --upgrade pip --root-user-action
-          pip3 install meson pyparsing toml tomli
+          #python3 -m pip install --upgrade pip
+          pip3 install --break-system-packages meson pyparsing toml tomli
 
       - name: Install Java
         uses: actions/setup-java@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,7 @@ jobs:
         # the base runner OS - we use the latest ubuntu, both in x86 and arm64
         os: [ubuntu-24.04, ubuntu-24.04-arm]
         # basic containers to use - ubuntu 22.04, ubuntu 24.04 and ubi9
-        # each will be built in both arm and x86 version
+        # each will be built in both arm and x86 versions
         container: [ubuntu:24.04, ubuntu:22.04, redhat/ubi9:latest]
         solver: [abc, bitwuzla, boolector, cvc4, cvc5, yices, z3-4.8.8, z3-4.8.14]
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,45 +20,24 @@ defaults:
 
 jobs:
   # This job captures native runners that cannot be neatly containerized
-  # There are docker containers for MacOS and Windows, but maybe they don't work that well?
-  # build-native:
-  #   runs-on: ${{ matrix.os }}
-  #   strategy:
-  #     fail-fast: false
-  #     os: [macos-15, macos-15-intel, windows-2022]
-  #     solver: [abc, bitwuzla, boolector, cvc4, cvc5, yices, z3-4.8.8, z3-4.8.14]
-
-  build-container:
+  build-native:
     runs-on: ${{ matrix.os }}
-    container:
-      image: ${{ matrix.container }}
     strategy:
       fail-fast: false
       matrix:
-        # the base runner OS - we use the latest ubuntu, both in x86 and arm64
-        os: [ubuntu-24.04, ubuntu-24.04-arm]
-        # basic containers to use - ubuntu 22.04, ubuntu 24.04 and ubi9
-        # each will be built in both arm and x86 version
-        container: [ubuntu:24.04, ubuntu:22.04, redhat/ubi9:latest, ]
+        os: [macos-15, macos-15-intel, windows-2022]
         solver: [abc, bitwuzla, boolector, cvc4, cvc5, yices, z3-4.8.8, z3-4.8.14]
     steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: true
+          fetch-depth: 0
       # This is necessary to clone the yices2 repo on Windows, as some of the
       # repo's test cases exceed the Windows API's default file path limit of
       # 260 characters.
       - name: Enable long file paths on Windows
         run: git config --system core.longpaths true
-        if: runner.os == 'Windows'
-
-      - uses: actions/checkout@v6
-        with:
-          submodules: true
-          fetch-depth: 0
-
-      - name: Install dependencies (Ubuntu)
-        run: |
-          sudo apt-get update
-          sudo apt-get install gperf automake autoconf libreadline-dev lzip ninja-build
-        if: runner.os == 'Linux'
+        if: contains(matrix.os, 'windows')
 
       - name: Install dependencies (macOS)
         run: |
@@ -68,7 +47,7 @@ jobs:
           # work around this, we install put GNU sed before macOS's sed on the
           # PATH.
           echo "PATH=/usr/local/opt/gnu-sed/libexec/gnubin:$PATH" >> $GITHUB_ENV
-        if: runner.os == 'macOS'
+        if: contains(matrix.os, 'macos')
 
       - name: Install dependencies (Windows)
         uses: msys2/setup-msys2@v2
@@ -92,7 +71,7 @@ jobs:
             patch
             tar
             unzip
-        if: runner.os == 'Windows'
+        if: contains(matrix.os, 'windows')
 
       - name: Install Python
         uses: actions/setup-python@v5
@@ -128,9 +107,6 @@ jobs:
         run: .github/ci.sh test_solver ${{ matrix.solver }}
         if: runner.os == 'Windows'
 
-      # Needed to normalize both "ubuntu-24.04" and "ubuntu-24.04-arm" to
-      # "ubuntu-24.04" so that the Ubuntu ARM64 binaries don't accidentally
-      # mention ARM twice (#63).
       - name: Normalize runner name
         run: echo "OS_NAME=$(.github/ci.sh normalize_runner_name ${{ matrix.os }})" >> $GITHUB_ENV
 
@@ -139,14 +115,18 @@ jobs:
           path: bin
           name: ${{ env.OS_NAME }}-${{ runner.arch }}-${{ matrix.solver }}-bin
 
-  build-ubi9:
+  build-container:
     runs-on: ${{ matrix.os }}
     container:
-      image: redhat/ubi9:latest
+      image: ${{ matrix.container }}
     strategy:
       fail-fast: false
       matrix:
+        # the base runner OS - we use the latest ubuntu, both in x86 and arm64
         os: [ubuntu-24.04, ubuntu-24.04-arm]
+        # basic containers to use - ubuntu 22.04, ubuntu 24.04 and ubi9
+        # each will be built in both arm and x86 version
+        container: [ubuntu:24.04, ubuntu:22.04, redhat/ubi9:latest]
         solver: [abc, bitwuzla, boolector, cvc4, cvc5, yices, z3-4.8.8, z3-4.8.14]
     steps:
 
@@ -162,6 +142,7 @@ jobs:
 
           # Install additional dependencies from EPEL
           dnf install -y --enablerepo=epel lzip
+        if: contains(matrix.container, 'redhat')
 
       - name: Install additional dependencies (Red Hat UBI 9)
         run: |
@@ -174,16 +155,36 @@ jobs:
           # Python: Required by Bitwuzla, Z3, Yices, CVC4, CVC5, Boolector
           # Java: Required by CVC4, CVC5 (for ANTLR)
           dnf install -y python3 python3-pip java-17-openjdk-devel
+        if: contains(matrix.container, 'redhat')
+
+      - uses: actions/checkout@v6
+        with:
+          submodules: true
+          fetch-depth: 0
+
+      - name: Install dependencies (Ubuntu)
+        run: |
+          sudo apt-get update
+          sudo apt-get install gperf automake autoconf libreadline-dev lzip ninja-build
+        if: contains(matrix.container, 'ubuntu')
+
+      - name: Install Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+        if: contains(matrix.container, 'ubuntu')
 
       - name: Install Python libraries
         run: |
           python3 -m pip install --upgrade pip
           pip3 install meson pyparsing toml tomli
 
-      - uses: actions/checkout@v6
+      - name: Install Java
+        uses: actions/setup-java@v3
         with:
-          submodules: true
-          fetch-depth: 0
+          distribution: 'temurin'
+          java-version: '17'
+        if: contains(matrix.container, 'ubuntu')
 
       - name: build_solver
         run: .github/ci.sh build_${{ matrix.solver }}
@@ -191,8 +192,8 @@ jobs:
       - name: test_solver
         run: .github/ci.sh test_solver ${{ matrix.solver }}
 
-      - name: Set OS name
-        run: echo "OS_NAME=redhat-ubi9" >> $GITHUB_ENV
+      - name: Normalize runner name
+        run: echo "OS_NAME=$(.github/ci.sh normalize_runner_name ${{ matrix.container }})" >> $GITHUB_ENV
 
       - uses: actions/upload-artifact@v4
         with:
@@ -201,7 +202,7 @@ jobs:
 
   package_solvers:
     runs-on: ubuntu-latest
-    needs: [build, build-ubi9]
+    needs: [build-native, build-container]
     strategy:
       fail-fast: false
       matrix:
@@ -300,6 +301,6 @@ jobs:
   # - dependencies through `needs:` are validated, CI will fail if it's invalid
   mergify:
     runs-on: ubuntu-24.04
-    needs: [build, build-ubi9]
+    needs: [build-native, build-container]
     steps:
       - run: "true"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,7 +178,7 @@ jobs:
       - name: Install dependencies (Ubuntu)
         run: |
           apt-get update
-          apt-get install -y gperf automake autoconf libreadline-dev lzip ninja-build git make gcc
+          apt-get install -y gperf automake autoconf libreadline-dev lzip ninja-build git make gcc curl cmake
         if: contains(matrix.container, 'ubuntu')
 
       - name: Install Python and Python libraries (Ubuntu)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,18 +180,12 @@ jobs:
           apt-get install -y gperf automake autoconf libreadline-dev lzip ninja-build git make gcc curl cmake libgmp-dev openjdk-17-jdk python3 python3-pip python3-venv
         if: contains(matrix.container, 'ubuntu')
 
-      - name: Install Python and Python libraries (Ubuntu)
+      - name: Install Python libraries
         run: |
           python3 -m venv /opt/venv
-          /opt/venv/bin/pip install meson pyparsing toml tomli
+          # setuptools provides distutils compatibility for Python 3.12+ (needed by z3-4.8.8)
+          /opt/venv/bin/pip install setuptools meson pyparsing toml tomli
           echo "PATH=/opt/venv/bin:$PATH" >> $GITHUB_ENV
-        if: contains(matrix.container, 'ubuntu')
-
-      - name: Install Python libraries (Red Hat UBI 9)
-        run: |
-          python3 -m pip install --upgrade pip
-          pip3 install meson pyparsing toml tomli
-        if: contains(matrix.container, 'redhat')
 
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,10 +28,6 @@ jobs:
         os: [macos-15, macos-15-intel, windows-2022]
         solver: [abc, bitwuzla, boolector, cvc4, cvc5, yices, z3-4.8.8, z3-4.8.14]
     steps:
-      - uses: actions/checkout@v6
-        with:
-          submodules: true
-          fetch-depth: 0
       # This is necessary to clone the yices2 repo on Windows, as some of the
       # repo's test cases exceed the Windows API's default file path limit of
       # 260 characters.
@@ -88,6 +84,11 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
+
+      - uses: actions/checkout@v6
+        with:
+          submodules: true
+          fetch-depth: 0
 
       - name: build_solver (non-Windows)
         run: .github/ci.sh build_${{ matrix.solver }}
@@ -157,15 +158,10 @@ jobs:
           dnf install -y python3 python3-pip java-17-openjdk-devel
         if: contains(matrix.container, 'redhat')
 
-      - uses: actions/checkout@v6
-        with:
-          submodules: true
-          fetch-depth: 0
-
       - name: Install dependencies (Ubuntu)
         run: |
           sudo apt-get update
-          sudo apt-get install gperf automake autoconf libreadline-dev lzip ninja-build
+          sudo apt-get install gperf automake autoconf libreadline-dev lzip ninja-build git
         if: contains(matrix.container, 'ubuntu')
 
       - name: Install Python
@@ -185,6 +181,11 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
         if: contains(matrix.container, 'ubuntu')
+
+      - uses: actions/checkout@v6
+        with:
+          submodules: true
+          fetch-depth: 0
 
       - name: build_solver
         run: .github/ci.sh build_${{ matrix.solver }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,7 +214,7 @@ jobs:
       - name: test_solver
         run: ./scripts/test-solvers.sh test_solver ${{ matrix.solver }} bin
 
-      - name: Normalize runner name
+      - name: Normalize container name
         run: echo "OS_NAME=$(.github/ci.sh normalize_runner_name ${{ matrix.container }})" >> $GITHUB_ENV
 
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,11 +130,12 @@ jobs:
           path: bin
           name: ${{ env.OS_NAME }}-${{ runner.arch }}-${{ matrix.solver }}-bin
 
+  # We use an unpinned image because downstream users typically use unpinned images as well.
+  # By using the `latest` tag we aim to catch any future breaking changes here.
   build-container:
+    name: build-container (${{ matrix.container }}, ${{ matrix.solver }})
     runs-on: ${{ matrix.os }}
     needs: check
-    # We use an unpinned image because downstream users typically use unpinned images as well.
-    # By using the `latest` tag we aim to catch any future breaking changes here.
     container:
       image: ${{ matrix.container }}
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,8 +189,8 @@ jobs:
 
       - name: Install Python libraries
         run: |
-          #python3 -m pip install --upgrade pip
-          pip3 install --break-system-packages meson pyparsing toml tomli
+          python3 -m pip install --upgrade pip
+          pip3 install meson pyparsing toml tomli
 
       - name: Install Java
         uses: actions/setup-java@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,7 +189,7 @@ jobs:
 
       - name: Install Python libraries
         run: |
-          python3 -m pip install --upgrade pip
+          python3 -m pip install --upgrade pip --root-user-action
           pip3 install meson pyparsing toml tomli
 
       - name: Install Java

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,10 +160,7 @@ jobs:
 
           # Install additional dependencies from EPEL
           dnf install -y --enablerepo=epel lzip
-        if: contains(matrix.container, 'redhat')
 
-      - name: Install additional dependencies (Red Hat UBI 9)
-        run: |
           # Build and install gperf from source (not available in UBI 9 repos)
           # Required by: Bitwuzla, Z3, Yices, CVC4, CVC5, Boolector
           curl -sL http://ftp.gnu.org/gnu/gperf/gperf-3.1.tar.gz | tar xz
@@ -178,12 +175,11 @@ jobs:
       - name: Install dependencies (Ubuntu)
         run: |
           apt-get update
-          apt-get install -y gperf automake autoconf libreadline-dev lzip ninja-build git make gcc curl cmake libgmp-dev
+          apt-get install -y gperf automake autoconf libreadline-dev lzip ninja-build git make gcc curl cmake libgmp-dev openjdk-17-jdk python3 python3-pip python3-venv
         if: contains(matrix.container, 'ubuntu')
 
       - name: Install Python and Python libraries (Ubuntu)
         run: |
-          apt-get install -y python3 python3-pip python3-venv
           # Use --break-system-packages only if pip supports it (pip >= 23.0)
           if pip3 install --help | grep -q break-system-packages; then
             pip3 install meson pyparsing toml tomli --break-system-packages
@@ -197,11 +193,6 @@ jobs:
           python3 -m pip install --upgrade pip
           pip3 install meson pyparsing toml tomli
         if: contains(matrix.container, 'redhat')
-
-      - name: Install Java (Ubuntu)
-        run: |
-          apt-get install -y openjdk-17-jdk
-        if: contains(matrix.container, 'ubuntu')
 
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,8 +175,8 @@ jobs:
 
       - name: Install dependencies (Ubuntu)
         run: |
-          sudo apt-get update
-          sudo apt-get install gperf automake autoconf libreadline-dev lzip ninja-build git
+          apt-get update
+          apt-get install gperf automake autoconf libreadline-dev lzip ninja-build git
         if: contains(matrix.container, 'ubuntu')
 
       - name: Install Python

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,7 +178,7 @@ jobs:
       - name: Install dependencies (Ubuntu)
         run: |
           apt-get update
-          apt-get install gperf automake autoconf libreadline-dev lzip ninja-build git
+          apt-get install -y gperf automake autoconf libreadline-dev lzip ninja-build git
         if: contains(matrix.container, 'ubuntu')
 
       - name: Install Python

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,6 +145,7 @@ jobs:
         os: [ubuntu-24.04, ubuntu-24.04-arm]
         # basic containers to use - ubuntu 22.04, ubuntu 24.04 and ubi9
         # each will be built in both arm and x86 versions
+        # if a ne containers is added, update normalize_container_name() function in ci.sh
         container: [ubuntu:24.04, ubuntu:22.04, redhat/ubi9:latest]
         solver: [abc, bitwuzla, boolector, cvc4, cvc5, yices, z3-4.8.8, z3-4.8.14]
     steps:
@@ -207,7 +208,7 @@ jobs:
         run: ./scripts/test-solvers.sh test_solver ${{ matrix.solver }} bin
 
       - name: Normalize container name
-        run: echo "OS_NAME=$(.github/ci.sh normalize_runner_name ${{ matrix.container }})" >> $GITHUB_ENV
+        run: echo "OS_NAME=$(.github/ci.sh normalize_container_name ${{ matrix.container }})" >> $GITHUB_ENV
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,12 +182,9 @@ jobs:
 
       - name: Install Python and Python libraries (Ubuntu)
         run: |
-          # Use --break-system-packages only if pip supports it (pip >= 23.0)
-          if pip3 install --help | grep -q break-system-packages; then
-            pip3 install meson pyparsing toml tomli --break-system-packages
-          else
-            pip3 install meson pyparsing toml tomli
-          fi
+          python3 -m venv /opt/venv
+          /opt/venv/bin/pip install meson pyparsing toml tomli
+          echo "PATH=/opt/venv/bin:$PATH" >> $GITHUB_ENV
         if: contains(matrix.container, 'ubuntu')
 
       - name: Install Python libraries (Red Hat UBI 9)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,7 +145,7 @@ jobs:
         os: [ubuntu-24.04, ubuntu-24.04-arm]
         # basic containers to use - ubuntu 22.04, ubuntu 24.04 and ubi9
         # each will be built in both arm and x86 versions
-        # if a ne containers is added, update normalize_container_name() function in ci.sh
+        # if a new container is added, update the normalize_container_name() function in ci.sh
         container: [ubuntu:24.04, ubuntu:22.04, redhat/ubi9:latest]
         solver: [abc, bitwuzla, boolector, cvc4, cvc5, yices, z3-4.8.8, z3-4.8.14]
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,7 @@ jobs:
   build-container:
     runs-on: ${{ matrix.os }}
     needs: check
-    # We use unpinned image because downstream users typically use unpinned images as well.
+    # We use an unpinned image because downstream users typically use unpinned images as well.
     # By using the `latest` tag we aim to catch any future breaking changes here.
     container:
       image: ${{ matrix.container }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,7 +178,7 @@ jobs:
       - name: Install dependencies (Ubuntu)
         run: |
           apt-get update
-          apt-get install -y gperf automake autoconf libreadline-dev lzip ninja-build git make gcc curl cmake
+          apt-get install -y gperf automake autoconf libreadline-dev lzip ninja-build git make gcc curl cmake libgmp-dev
         if: contains(matrix.container, 'ubuntu')
 
       - name: Install Python and Python libraries (Ubuntu)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,11 +198,9 @@ jobs:
           pip3 install meson pyparsing toml tomli
         if: contains(matrix.container, 'redhat')
 
-      - name: Install Java
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'temurin'
-          java-version: '17'
+      - name: Install Java (Ubuntu)
+        run: |
+          apt-get install -y openjdk-17-jdk
         if: contains(matrix.container, 'ubuntu')
 
       - uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,12 +19,27 @@ defaults:
     shell: bash
 
 jobs:
-  build:
+  # This job captures native runners that cannot be neatly containerized
+  # There are docker containers for MacOS and Windows, but maybe they don't work that well?
+  # build-native:
+  #   runs-on: ${{ matrix.os }}
+  #   strategy:
+  #     fail-fast: false
+  #     os: [macos-15, macos-15-intel, windows-2022]
+  #     solver: [abc, bitwuzla, boolector, cvc4, cvc5, yices, z3-4.8.8, z3-4.8.14]
+
+  build-container:
     runs-on: ${{ matrix.os }}
+    container:
+      image: ${{ matrix.container }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, ubuntu-22.04-arm, ubuntu-24.04-arm, ubuntu-22.04, macos-15, macos-15-intel, windows-2022]
+        # the base runner OS - we use the latest ubuntu, both in x86 and arm64
+        os: [ubuntu-24.04, ubuntu-24.04-arm]
+        # basic containers to use - ubuntu 22.04, ubuntu 24.04 and ubi9
+        # each will be built in both arm and x86 version
+        container: [ubuntu:24.04, ubuntu:22.04, redhat/ubi9:latest, ]
         solver: [abc, bitwuzla, boolector, cvc4, cvc5, yices, z3-4.8.8, z3-4.8.14]
     steps:
       # This is necessary to clone the yices2 repo on Windows, as some of the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
   # This job captures native runners that cannot be neatly containerized
   build-native:
     runs-on: ${{ matrix.os }}
+    needs: check
     strategy:
       fail-fast: false
       matrix:
@@ -131,6 +132,7 @@ jobs:
 
   build-container:
     runs-on: ${{ matrix.os }}
+    needs: check
     # We use unpinned image because downstream users typically use unpinned images as well.
     # By using the `latest` tag we aim to catch any future breaking changes here.
     container:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,19 +178,25 @@ jobs:
       - name: Install dependencies (Ubuntu)
         run: |
           apt-get update
-          apt-get install -y gperf automake autoconf libreadline-dev lzip ninja-build git
+          apt-get install -y gperf automake autoconf libreadline-dev lzip ninja-build git make gcc
         if: contains(matrix.container, 'ubuntu')
 
-      - name: Install Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.10'
+      - name: Install Python and Python libraries (Ubuntu)
+        run: |
+          apt-get install -y python3 python3-pip python3-venv
+          # Use --break-system-packages only if pip supports it (pip >= 23.0)
+          if pip3 install --help | grep -q break-system-packages; then
+            pip3 install meson pyparsing toml tomli --break-system-packages
+          else
+            pip3 install meson pyparsing toml tomli
+          fi
         if: contains(matrix.container, 'ubuntu')
 
-      - name: Install Python libraries
+      - name: Install Python libraries (Red Hat UBI 9)
         run: |
           python3 -m pip install --upgrade pip
           pip3 install meson pyparsing toml tomli
+        if: contains(matrix.container, 'redhat')
 
       - name: Install Java
         uses: actions/setup-java@v3


### PR DESCRIPTION
Instead of using native runners for all but Ubi9 builds, use container for all linux builds, and keep native runners for MacOS and Windows only. This previews how such a workflow would look for more complex CI pipelines (such as in SAW)