### PR TITLE
Sign and notarize macOS solvers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,15 +176,18 @@ jobs:
           # Install base build tools (including glibc-static and libstdc++-static for static linking)
           # This includes all dependencies needed across all solvers
           dnf install -y gcc gcc-c++ make git patch tar unzip automake autoconf cmake ninja-build \
-            glibc-static libstdc++-static gmp-devel
+            glibc-static libstdc++-static gmp-devel diffutils
 
           # Install additional dependencies from EPEL
           dnf install -y --enablerepo=epel lzip
 
-          # Build and install gperf from source (not available in UBI 9 repos)
-          # Required by: Bitwuzla, Z3, Yices, CVC4, CVC5, Boolector
+          # Build and install gperf and bison from source (not available in UBI 9 repos)
+          # gperf: Required by Bitwuzla, Z3, Yices, CVC4, CVC5, Boolector
+          # bison: Required by CVC5
           curl -sL http://ftp.gnu.org/gnu/gperf/gperf-3.1.tar.gz | tar xz
           cd gperf-3.1 && ./configure && make -j4 && make install && cd .. && rm -rf gperf-3.1
+          curl -sL http://ftp.gnu.org/gnu/bison/bison-3.8.tar.gz | tar xz
+          cd bison-3.8 && ./configure && make -j4 && make install && cd .. && rm -rf bison-3.8
 
           # Install Python 3 and Java
           # Python: Required by Bitwuzla, Z3, Yices, CVC4, CVC5, Boolector

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,13 @@ jobs:
         run: git config --system core.longpaths true
         if: contains(matrix.os, 'windows')
 
+      - name: Import signing certificate (macOS)
+        uses: apple-actions/import-codesign-certs@v3
+        if: contains(matrix.os, 'macos')
+        with:
+          p12-file-base64: ${{ secrets.APPLE_P12_CERTIFICATE }}
+          p12-password: ${{ secrets.APPLE_P12_PASSWORD }}
+
       - name: Install dependencies (macOS)
         run: |
           brew update
@@ -112,6 +119,17 @@ jobs:
         shell: msys2 {0}
         run: .github/ci.sh build_${{ matrix.solver }}
         if: runner.os == 'Windows'
+
+      - name: Sign binary (macOS)
+        if: contains(matrix.os, 'macos')
+        env:
+          IDENTITY_NAME: ${{ secrets.APPLE_P12_IDENTITY_NAME }}
+        run: |
+          codesign \
+            --force \
+            --options runtime \
+            --sign "$IDENTITY_NAME" \
+            bin/${{ matrix.solver }}
 
       - name: test_solver (non-Windows)
         run: ./scripts/test-solvers.sh test_solver ${{ matrix.solver }} bin
@@ -299,6 +317,45 @@ jobs:
         with:
           path: bin
           name: ${{ matrix.os }}-${{ matrix.arch }}-bin
+
+  # Notarize the macOS binaries. Note that Apple's documentation suggests that
+  # you shouldn't notarize more than 75 times in one day
+  # (https://developer.apple.com/documentation/security/customizing-the-notarization-workflow#Avoid-long-notarization-response-times-and-size-limits),
+  # so as a precaution, we only perform this step when a commit is on the
+  # `main` branch (and not in pull requests).
+  notarize_macos_solvers:
+    runs-on: ${{ matrix.os }}
+    needs: [package_solvers]
+    if: (github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch') &&
+        github.event.pull_request.head.repo.fork == false &&
+        github.repository_owner == 'GaloisInc'
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-15]
+        arch: [ARM64, X64]
+    steps:
+      - uses: actions/download-artifact@v6
+        with:
+          name: "${{ matrix.os }}-${{ matrix.arch }}-bin"
+          path: bin
+
+      - name: Zip binaries
+        run: |
+          zip binaries.zip bin/*
+
+      - name: Notarize binaries
+        env:
+          KEY_ID: ${{ secrets.APPLE_P8_KEY_ID }}
+          ISSUER_ID: ${{ secrets.APPLE_P8_ISSUER_ID }}
+          API_KEY: ${{ secrets.APPLE_P8_API_KEY }}
+        run: |
+          echo "$API_KEY" > "AuthKey_$KEY_ID.p8"
+          xcrun notarytool submit binaries.zip \
+            --key "AuthKey_$KEY_ID.p8" \
+            --key-id "$KEY_ID" \
+            --issuer "$ISSUER_ID" \
+            --wait
 
   # Indicates sufficient CI success for the purposes of mergify merging the pull
   # request, see .github/mergify.yml. This is done instead of enumerating each

--- a/patches/cvc4-antlr-check-aarch64.patch
+++ b/patches/cvc4-antlr-check-aarch64.patch
@@ -1,19 +1,39 @@
 diff --git a/contrib/get-antlr-3.4 b/contrib/get-antlr-3.4
-index 45dc86583..685623f19 100755
+index 45dc86583..5df3e95d8 100755
 --- a/contrib/get-antlr-3.4
 +++ b/contrib/get-antlr-3.4
-@@ -26,6 +26,22 @@ if [ -z "${MACHINE_TYPE}" ]; then
+@@ -7,12 +7,18 @@ if [ -z "${BUILD_TYPE}" ]; then
+   BUILD_TYPE="--disable-shared --enable-static"
+ fi
+ 
++# Obtain a more recent version of config.guess. While we could download this
++# from the upstream GNU Savannah repo, in practice this ends up being extremely
++# flaky due to Savannah's frequent downtime. (See
++# https://github.com/doomemacs/core/issues/7171 as one example.) Instead, we
++# obtain config.guess by copying the version bundled with the automake tool.
++# This version isn't as up-to-date as the upstream one, but that's fine. We
++# just need *some* version that is reasonably modern, and that will do.
+ if [ -z "${MACHINE_TYPE}" ]; then
+   CONFIG_GUESS_SCRIPT="$ANTLR_HOME_DIR/config.guess"
+   if ! [ -e "${CONFIG_GUESS_SCRIPT}" ]; then
+     mkdir -p "$ANTLR_HOME_DIR"
+-    # Attempt to download once
+-    webget 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD' $CONFIG_GUESS_SCRIPT
++    cp "$(automake --print-libdir)/config.guess" $CONFIG_GUESS_SCRIPT
+     if [ -e "$CONFIG_GUESS_SCRIPT" ]; then
+      chmod +x "$CONFIG_GUESS_SCRIPT"
+    else
+@@ -26,6 +32,21 @@ if [ -z "${MACHINE_TYPE}" ]; then
    MACHINE_TYPE=$(${CONFIG_GUESS_SCRIPT} | sed 's,-.*,,')
  fi
  
-+# In addition to config.guess, we also download a more recent version of
++# In addition to config.guess, we also obtain a more recent version of
 +# config.sub. We aren't going to use it directly in this script, but we will
 +# copy it into our ANTLR checkout later.
 +CONFIG_SUB_SCRIPT="$ANTLR_HOME_DIR/config.sub"
 +if ! [ -e "${CONFIG_SUB_SCRIPT}" ]; then
 +  mkdir -p "$ANTLR_HOME_DIR"
-+  # Attempt to download once
-+  webget 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=HEAD' $CONFIG_SUB_SCRIPT
++  cp "$(automake --print-libdir)/config.sub" $CONFIG_SUB_SCRIPT
 +  if [ -e "$CONFIG_SUB_SCRIPT" ]; then
 +    chmod +x "$CONFIG_SUB_SCRIPT"
 +  else
@@ -25,7 +45,7 @@ index 45dc86583..685623f19 100755
  mkdir -p "$INSTALL_DIR/share/java"
  webget \
    "https://www.antlr3.org/download/antlr-3.4-complete.jar" \
-@@ -43,11 +59,22 @@ install_bin "$ANTLR_HOME_DIR/bin/antlr3"
+@@ -43,11 +64,22 @@ install_bin "$ANTLR_HOME_DIR/bin/antlr3"
  setup_dep \
    "https://www.antlr3.org/download/C/libantlr3c-3.4.tar.gz" \
    "$ANTLR_HOME_DIR/libantlr3c-3.4"
@@ -49,7 +69,7 @@ index 45dc86583..685623f19 100755
    # 64-bit stuff here
    ./configure --enable-64bit --disable-antlrdebug --prefix="$INSTALL_DIR" $ANTLR_CONFIGURE_ARGS $BUILD_TYPE
  else
-@@ -67,7 +94,7 @@ fi
+@@ -67,7 +99,7 @@ fi
  mv "$INSTALL_LIB_DIR/libantlr3c.a" "$INSTALL_LIB_DIR/libantlr3c-static.a"
  make clean
  
@@ -58,7 +78,7 @@ index 45dc86583..685623f19 100755
    # 64-bit stuff here
    ./configure --enable-64bit --with-pic --disable-antlrdebug --prefix="$INSTALL_DIR" $ANTLR_CONFIGURE_ARGS $BUILD_TYPE
  else
-@@ -84,7 +111,7 @@ mv "$INSTALL_LIB_DIR/libantlr3c.la" "$INSTALL_LIB_DIR/libantlr3c.la.orig"
+@@ -84,7 +116,7 @@ mv "$INSTALL_LIB_DIR/libantlr3c.la" "$INSTALL_LIB_DIR/libantlr3c.la.orig"
  awk '/^old_library=/ {print "old_library='\''libantlr3c-static.a'\''"} /^library_names=/ {print "library_names='\''libantlr3c.a'\''"} !/^old_library=/ && !/^library_names=/ {print}' < "$INSTALL_LIB_DIR/libantlr3c.la.orig" > "$INSTALL_LIB_DIR/libantlr3c.la"
  rm "$INSTALL_LIB_DIR/libantlr3c.la.orig"
  


### PR DESCRIPTION
We sign on every commit. We only notarize when pushing to `main` to avoid rate limits that Apple's notarization servers may impose (see https://developer.apple.com/documentation/security/customizing-the-notarization-workflow#Avoid-long-notarization-response-times-and-size-limits).

Fixes https://github.com/GaloisInc/what4-solvers/issues/86.